### PR TITLE
Prevent NullPointerException when joining a world

### DIFF
--- a/src/main/java/com/paragon/client/systems/module/impl/movement/NoFall.java
+++ b/src/main/java/com/paragon/client/systems/module/impl/movement/NoFall.java
@@ -91,6 +91,9 @@ public class NoFall extends Module {
 
     @Listener
     public void onPacketSent(PacketEvent.PreSend event) {
+        if(mc.player == null || mc.playerController == null) {
+            return;
+        }
         // Ignore if we are flying with an elytra, or we are in creative mode
         if (mc.player.isElytraFlying() && ignoreElytra.getValue() || mc.playerController.getCurrentGameType().equals(GameType.CREATIVE)) {
             return;

--- a/src/main/java/com/paragon/client/systems/module/impl/movement/NoFall.java
+++ b/src/main/java/com/paragon/client/systems/module/impl/movement/NoFall.java
@@ -91,7 +91,7 @@ public class NoFall extends Module {
 
     @Listener
     public void onPacketSent(PacketEvent.PreSend event) {
-        if(mc.player == null || mc.playerController == null) {
+        if(nullCheck()) {
             return;
         }
         // Ignore if we are flying with an elytra, or we are in creative mode


### PR DESCRIPTION
This simple pr fixed a NullPointerException that occurred to me when I tried joining a world with nofall enabled.